### PR TITLE
Update zh_cn.json

### DIFF
--- a/common/src/main/resources/assets/harvestseason/lang/zh_cn.json
+++ b/common/src/main/resources/assets/harvestseason/lang/zh_cn.json
@@ -1,13 +1,17 @@
 {
-	"item.harvestseason.grim_apple": "纸袋",
-	"gui.harvestseason.carving.edit": "雕刻",
-	"gui.harvestseason.carving.clear": "清除",
+    "item.harvestseason.grim_apple": "纸袋",
+    "gui.harvestseason.carving.edit": "雕刻",
+    "gui.harvestseason.carving.clear": "清除",
     "item.harvestseason.corn": "玉米",
     "item.harvestseason.corn_on_the_cob": "烤玉米",
     "item.harvestseason.popcorn": "爆米花",
-    "item.harvestseason.candy_corn": "玉米糖果",
+    "item.harvestseason.candy_corn": "玉米糖",
+    "item.harvestseason.kernels": "玉米粒",
     "block.harvestseason.paper_bag": "纸袋",
     "block.harvestseason.candy_bag": "糖果袋",
-    "block.harvestseason.jack_o_lantern": "可雕刻的南瓜灯",
-    "block.harvestseason.carved_pumpkin": "可雕刻的南瓜"
+    "block.harvestseason.jack_o_lantern": "南瓜灯",
+    "block.harvestseason.carved_pumpkin": "雕刻过的南瓜",
+    "item.harvestseason.succotash": "玉米杂烩",
+    "block.harvestseason.corn_crate": "箱装玉米",
+    "item.harvestseason.cornbread": "玉米面包"
 }


### PR DESCRIPTION
Updated keys for `Jack o' Lantern` & `Carved Pumpkin` to fit Vanilla word choices.
Their former version means `Carvable Jack o' Lantern` & `Carvable Pumpkin`

*i actually don't know if those words should be distinguished from their vanilla versions or not*